### PR TITLE
Corregido markdown lint persona-encarni.md

### DIFF
--- a/doc/persona-encarni.md
+++ b/doc/persona-encarni.md
@@ -2,16 +2,21 @@
 
 ## Encarni, 42 años
 
-- Nombre y apellido: Encarnación Jiménez Roldán
-- Edad: 42 años
-- Localidad: Jun, Granada
-- Ocupación: Jefa de Proyectos
-- Estado civil: Casada
-- Nivel cultural: Elevado. Graduada en Edificación y Administración de Empresas. Tiene el C2 en inglés y C1 en francés y alemán
-- Frase que describe a la persona: Profesional entregada a su trabajo y su familia, no se rendirá hasta lograr sus objetivos
-- Motivaciones: Quiere planear muchos viajes con su familia (su pareja y sus dos hijos)
-- Deseos: Ir a Orlando con su familia y visitar todos los parques de atracciones
-- Preocupaciones: No dedicarle el tiempo suficiente a sus hijos debido al trabajo
-- Manías: No puede dejar un proyecto sin acabar
-- Miedos: Quedarse estancada en la rutina
-- Hobbies: Ir a la playa, surfear, viajar y realizar rutas
+* Nombre y apellido: Encarnación Jiménez Roldán
+* Edad: 42 años
+* Localidad: Jun, Granada
+* Ocupación: Jefa de Proyectos
+* Estado civil: Casada
+* Nivel cultural: Elevado. Graduada en Edificación y Administración de
+  Empresas. Tiene el C2 en inglés y C1 en francés y alemán
+* Frase que describe a la persona: Profesional entregada a su trabajo y su
+  familia, no se rendirá hasta lograr sus objetivos
+* Motivaciones: Quiere planear muchos viajes con su familia (su pareja y sus
+  dos hijos)
+* Deseos: Ir a Orlando con su familia y visitar todos los parques de
+  atracciones
+* Preocupaciones: No dedicarle el tiempo suficiente a sus hijos debido al
+  trabajo
+* Manías: No puede dejar un proyecto sin acabar
+* Miedos: Quedarse estancada en la rutina
+* Hobbies: Ir a la playa, surfear, viajar y realizar rutas


### PR DESCRIPTION
# Corrección markdown lint persona-Encarni.md

## Descripción

Se han corregido los fallos ortográficos y de formato del fichero markdown.

## Cambios realizados

* Sustituido "-" por "*" para las listas sin orden
* Respetado el límite de 80 caracteres por línea
* Añadido un newline character al final del archivo

## Issue relacionado

Fixes issue https://github.com/JJ/KeMeVoi/issues/17
